### PR TITLE
Add basic support for MacVim (mvim)

### DIFF
--- a/lib/open-vim.coffee
+++ b/lib/open-vim.coffee
@@ -6,31 +6,16 @@ module.exports =
     atom.workspaceView.command "open-vim:open", => @open()
 
   open: ->
-    exec "uname -s", (error, stdout, sterr) ->
+    exec "uname -s", (error, stdout, stderr) ->
       if error
-        alert("operating system could not be detected")
+        alert "operating system could not be detected"
       else
-        if stdout
-          # Mac
-          if stdout.indexOf("Darwin") isnt -1
-            exec "which mvim", (error, stdout, stderr) ->
-              if error
-                alert("mvim not found")
-              editor = atom.workspace.getActivePaneItem()
-              filePath = editor?.buffer.file?.path
-              if filePath
-                exec "mvim --remote-silent #{filePath}"
-  
-          # Linux  
-          else if stdout.indexOf("Linux") isnt -1
-            exec "which gvim", (error, stdout, stderr) ->
-              if error
-                alert("gvim not found")
-              editor = atom.workspace.getActivePaneItem()
-              filePath = editor?.buffer.file?.path
-              if filePath
-                exec "gvim --remote-silent #{filePath}"
-          else
-            alert("operating system not supported")
-        else
-          alert("operating system could not be detected")
+        vimType = if stdout is "Darwin\n" then "mvim" else "gvim"
+
+        exec "which #{vimType}", (error, stdout, stderr) ->
+          if error
+            alert "#{vimType} not found"
+          editor = atom.workspace.getActivePaneItem()
+          filePath = editor?.buffer.file?.path
+          if filePath
+            exec "#{vimType} --remote-silent #{filePath}"

--- a/lib/open-vim.coffee
+++ b/lib/open-vim.coffee
@@ -6,10 +6,31 @@ module.exports =
     atom.workspaceView.command "open-vim:open", => @open()
 
   open: ->
-    exec "which gvim", (error, stdout, stderr) ->
+    exec "uname -s", (error, stdout, sterr) ->
       if error
-        alert("gvim not found")
-      editor = atom.workspace.getActivePaneItem()
-      filePath = editor?.buffer.file?.path
-      if filePath
-        exec "gvim --remote-silent #{filePath}"
+        alert("operating system could not be detected")
+      else
+        if stdout
+          # Mac
+          if stdout.indexOf("Darwin") isnt -1
+            exec "which mvim", (error, stdout, stderr) ->
+              if error
+                alert("mvim not found")
+              editor = atom.workspace.getActivePaneItem()
+              filePath = editor?.buffer.file?.path
+              if filePath
+                exec "mvim --remote-silent #{filePath}"
+  
+          # Linux  
+          else if stdout.indexOf("Linux") isnt -1
+            exec "which gvim", (error, stdout, stderr) ->
+              if error
+                alert("gvim not found")
+              editor = atom.workspace.getActivePaneItem()
+              filePath = editor?.buffer.file?.path
+              if filePath
+                exec "gvim --remote-silent #{filePath}"
+          else
+            alert("operating system not supported")
+        else
+          alert("operating system could not be detected")


### PR DESCRIPTION
Check what operating system is used and run `mvim` or `gvim` for Mac or Linux, respectively.
