### PR TITLE
Set vim cursor at the same locaion with atom

### DIFF
--- a/lib/open-vim.coffee
+++ b/lib/open-vim.coffee
@@ -31,7 +31,8 @@ module.exports =
     if editor
       filePath = editor.getPath()
       lineNum  = editor.bufferPositionForScreenPosition(editor.getCursorScreenPosition()).row + 1 # +1 to get actual line
-      execFile vimType, ["--remote-silent", "+#{lineNum}", filePath], (error, stdout, stderr) ->
+      colNum   = editor.bufferPositionForScreenPosition(editor.getCursorScreenPosition()).column + 1
+      execFile vimType, ["--remote-silent", "+call cursor(#{lineNum}, #{colNum})", filePath], (error, stdout, stderr) ->
         if error
           atom.notifications.addError error.message
 


### PR DESCRIPTION
Just one more improvement.  We've already have vim started with cursor on same line in atom. Now, the cursor will also be in the same column.
